### PR TITLE
Update rubocop template to include new cops by default

### DIFF
--- a/rubocop.yml.tt
+++ b/rubocop.yml.tt
@@ -1,6 +1,7 @@
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
+  NewCops: enable
   TargetRubyVersion: <%= RUBY_VERSION[/\d+\.\d+/] %>
   Exclude:
     - "bin/*"
@@ -24,6 +25,12 @@ Style/ClassAndModuleChildren:
 Layout/IndentationConsistency:
   EnforcedStyle: indented_internal_methods
 
+Layout/LineLength:
+  Max: 150
+  Exclude:
+    - "config/**/*"
+    - "db/**/*"
+
 Metrics/AbcSize:
   Exclude:
     - "spec/**/*"
@@ -37,12 +44,6 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Exclude:
     - "spec/**/*"
-
-Metrics/LineLength:
-  Max: 150
-  Exclude:
-    - "config/**/*"
-    - "db/**/*"
 
 Metrics/MethodLength:
   Max: 12


### PR DESCRIPTION
This is configuring Rubocop to use new cops by default as described in the docs:
https://docs.rubocop.org/rubocop/0.88/versioning.html#pending-cops

Also changing the scope of LineLength cop to Layout, not sure if this changed in the newer version but this is where it's supposed to be not under Metrics.