### PR TITLE
Add posibility to specify Sidekiq queue on ServiceInvocationWorker

### DIFF
--- a/lib/service/base.rb
+++ b/lib/service/base.rb
@@ -19,11 +19,15 @@ module Service
     end
 
     def self.async_call(**params)
-      ServiceInvocationWorker.perform_async(to_s, params)
+      queue = params.delete(:queue) || :default
+
+      ServiceInvocationWorker.set(queue: queue).perform_async(to_s, params)
     end
 
     def self.scheduled_call(time, **params)
-      ServiceInvocationWorker.perform_in(time, to_s, params)
+      queue = params.delete(:queue) || :default
+
+      ServiceInvocationWorker.set(queue: queue).perform_in(time, to_s, params)
     end
 
     def initialize(**params)


### PR DESCRIPTION
I encountered this use case where I had a service that I wanted to perform async, but also specify the Sidekiq queue in which to push it. 
With this change, everything should work as usual but also allow you to specify the Sidekiq queue if you want.

Example:
```ruby
MyService.async_call(params: params) # => default Sidekiq queue

MyService.async_call(params: params, queue: :critical) # => critical Sidekiq queue 
```
 