### PR TITLE
Fix CircleCI install dependencies step to use cached gems

### DIFF
--- a/circleci/config.yml.tt
+++ b/circleci/config.yml.tt
@@ -32,8 +32,8 @@ jobs:
           name: Install dependencies
           command: |
             gem install bundler --no-document --conservative
-            bundle update --bundler
-            bundle install --deployment --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set deployment 'true'
+            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
             bundle clean
 
       - save_cache:


### PR DESCRIPTION
I recently noticed that CircleCI was always installing the gems on every CI run even though the gems were cached.
This PR fixes that and saves some precious time from each CI run.

This also takes care of the deprecation of `--deployment` flag used to configure bundler for the production environment.

https://devcenter.heroku.com/changelog-items/1930