### PR TITLE
Update overcommit for psych 4.x

### DIFF
--- a/Gemfile.tt
+++ b/Gemfile.tt
@@ -49,7 +49,7 @@ group :development do
   gem 'bundler-audit', '~> 0.8.0', require: false
   gem 'letter_opener', '~> 1.7'
   gem 'listen'<%= gemfile_requirement('listen') %>
-  gem 'overcommit', '~> 0.57.0', require: false
+  gem 'overcommit', '~> 0.58.0', require: false
   gem 'rails-erd'
   gem 'rubocop', '~> 1.15', require: false
   gem 'spring', '~> 2.1', '>= 2.1.1'


### PR DESCRIPTION
Issue #35 
Upgrade overcommit gem from `0.57` to `0.58`.

Change: https://my.diffend.io/gems/overcommit/0.57.0/0.58.0#d2h-627053