### PR TITLE
Use context description for doc_title as default

### DIFF
--- a/spec/support/apipie_helper.rb
+++ b/spec/support/apipie_helper.rb
@@ -2,7 +2,7 @@
 
 module ApipieRecorderPatch
   def record
-    super.try(:merge, title: RSpec.current_example.metadata[:doc_title] || 'Default')
+    super.try(:merge, title: RSpec.current_example.metadata[:doc_title] || RSpec.current_example.example_group.description)
   end
 end
 


### PR DESCRIPTION
If doc_title not provied to the example, it will take the description from the context as doc_title.